### PR TITLE
[2.4] Added new CSS properties to #notification to control the mouseover fade opacity level.

### DIFF
--- a/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -867,6 +867,9 @@ StScrollBar StButton#vhandle:hover
     margin-from-right-edge-of-screen: 20px;    
     width: 34em;
     color: white;    
+    /* The px are a temporary fix until get_theme_node() can return raw numbers. */
+    opacity:255px;
+    mouseover-opacity:96px
 }
 
 #notification.multi-line-notification {

--- a/usr/share/themes/Mint-X/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-X/cinnamon/cinnamon.css
@@ -931,6 +931,9 @@ StScrollBar StButton#vhandle:hover
     margin-from-right-edge-of-screen: 20px;    
     width: 34em;
     color: rgb(70,70,70);
+    /* The px are a temporary fix until get_theme_node() can return raw numbers. */
+    opacity:255px;
+    mouseover-opacity:96px
 }
 
 #notification.multi-line-notification {


### PR DESCRIPTION
Currently Cinnamon does not support retrieving a raw number value from CSS, so a temporary fix using a length value is used.
