### PR TITLE
Show trash icon on expo completely

### DIFF
--- a/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
+++ b/usr/share/themes/Linux Mint/cinnamon/cinnamon.css
@@ -496,6 +496,7 @@ StScrollBar StButton#vhandle:hover
 
 .window-close-area {
   background-image: url("trash-icon.png");
+  background-size: cover;
   background-color: rgba(60, 60, 60, 0.8);
   border: 4px solid rgba(128,128,128,0.8);
   border-bottom-width: 0px;


### PR DESCRIPTION
The trash icon on the window-close area was displayed too large; fixed it in CSS.

Fix for linuxmint/Cinnamon#3674

![screenshot from 2014-11-26 16 09 30](https://cloud.githubusercontent.com/assets/5564491/5203421/cefd1992-7586-11e4-96a5-5826cc1e2e10.png)
