### PR TITLE
Fix for warnings generated by undefined -gradient-end/-gradient-start properties.

### DIFF
--- a/usr/share/themes/Mint-X-Aqua/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-X-Aqua/cinnamon/cinnamon.css
@@ -279,7 +279,10 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .popup-separator-menu-item {
-    background-color: rgb(210, 210, 210);
+    -gradient-height: 1px;
+    -gradient-start: rgb(210, 210, 210);
+    -gradient-end: rgb(210, 210, 210);
+    -margin-horizontal: 0;
     height: 1px;
 }
 

--- a/usr/share/themes/Mint-X-Blue/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-X-Blue/cinnamon/cinnamon.css
@@ -279,7 +279,10 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .popup-separator-menu-item {
-    background-color: rgb(210, 210, 210);
+    -gradient-height: 1px;
+    -gradient-start: rgb(210, 210, 210);
+    -gradient-end: rgb(210, 210, 210);
+    -margin-horizontal: 0;
     height: 1px;
 }
 

--- a/usr/share/themes/Mint-X-Brown/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-X-Brown/cinnamon/cinnamon.css
@@ -279,7 +279,10 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .popup-separator-menu-item {
-    background-color: rgb(210, 210, 210);
+    -gradient-height: 1px;
+    -gradient-start: rgb(210, 210, 210);
+    -gradient-end: rgb(210, 210, 210);
+    -margin-horizontal: 0;
     height: 1px;
 }
 

--- a/usr/share/themes/Mint-X-Orange/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-X-Orange/cinnamon/cinnamon.css
@@ -279,7 +279,10 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .popup-separator-menu-item {
-    background-color: rgb(210, 210, 210);
+    -gradient-height: 1px;
+    -gradient-start: rgb(210, 210, 210);
+    -gradient-end: rgb(210, 210, 210);
+    -margin-horizontal: 0;
     height: 1px;
 }
 

--- a/usr/share/themes/Mint-X-Pink/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-X-Pink/cinnamon/cinnamon.css
@@ -279,7 +279,10 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .popup-separator-menu-item {
-    background-color: rgb(210, 210, 210);
+    -gradient-height: 1px;
+    -gradient-start: rgb(210, 210, 210);
+    -gradient-end: rgb(210, 210, 210);
+    -margin-horizontal: 0;
     height: 1px;
 }
 

--- a/usr/share/themes/Mint-X-Purple/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-X-Purple/cinnamon/cinnamon.css
@@ -279,7 +279,10 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .popup-separator-menu-item {
-    background-color: rgb(210, 210, 210);
+    -gradient-height: 1px;
+    -gradient-start: rgb(210, 210, 210);
+    -gradient-end: rgb(210, 210, 210);
+    -margin-horizontal: 0;
     height: 1px;
 }
 

--- a/usr/share/themes/Mint-X-Red/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-X-Red/cinnamon/cinnamon.css
@@ -279,7 +279,10 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .popup-separator-menu-item {
-    background-color: rgb(210, 210, 210);
+    -gradient-height: 1px;
+    -gradient-start: rgb(210, 210, 210);
+    -gradient-end: rgb(210, 210, 210);
+    -margin-horizontal: 0;
     height: 1px;
 }
 

--- a/usr/share/themes/Mint-X-Sand/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-X-Sand/cinnamon/cinnamon.css
@@ -279,7 +279,10 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .popup-separator-menu-item {
-    background-color: rgb(210, 210, 210);
+    -gradient-height: 1px;
+    -gradient-start: rgb(210, 210, 210);
+    -gradient-end: rgb(210, 210, 210);
+    -margin-horizontal: 0;
     height: 1px;
 }
 

--- a/usr/share/themes/Mint-X-Teal/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-X-Teal/cinnamon/cinnamon.css
@@ -280,7 +280,10 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .popup-separator-menu-item {
-    background-color: rgb(210, 210, 210);
+    -gradient-height: 1px;
+    -gradient-start: rgb(210, 210, 210);
+    -gradient-end: rgb(210, 210, 210);
+    -margin-horizontal: 0;
     height: 1px;
 }
 

--- a/usr/share/themes/Mint-X/cinnamon/cinnamon.css
+++ b/usr/share/themes/Mint-X/cinnamon/cinnamon.css
@@ -279,7 +279,10 @@ StScrollBar StButton#vhandle:hover {
 }
 
 .popup-separator-menu-item {
-    background-color: rgb(210, 210, 210);
+    -gradient-height: 1px;
+    -gradient-start: rgb(210, 210, 210);
+    -gradient-end: rgb(210, 210, 210);
+    -margin-horizontal: 0;
     height: 1px;
 }
 


### PR DESCRIPTION
This change prevents the **.xsession-errors** file to be flooded with warnings like the following every time a Cinnamon menu is opened.
```
St-WARNING **: Did not find color property '-gradient-start'
```